### PR TITLE
Different approach on AuthenticationService

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/service/AuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/AuthenticationService.java
@@ -16,32 +16,15 @@ import java.util.UUID;
  * Service used for authenticating users.
  */
 public abstract class AuthenticationService extends Service {
-    protected String clientToken;
     protected String accessToken;
     protected boolean loggedIn;
     protected String username;
-    protected String password;
     protected GameProfile selectedProfile;
     protected List<GameProfile.Property> properties = new ArrayList<>();
     protected List<GameProfile> profiles = new ArrayList<>();
 
-    public AuthenticationService(String clientToken, URI defaultURI) {
+    public AuthenticationService(URI defaultURI) {
         super(defaultURI);
-
-        if(clientToken == null) {
-            throw new IllegalArgumentException("ClientToken cannot be null.");
-        }
-
-        this.clientToken = clientToken;
-    }
-
-    /**
-     * Gets the client token of the service.
-     *
-     * @return The service's client token.
-     */
-    public String getClientToken() {
-        return this.clientToken;
     }
 
     /**
@@ -72,15 +55,6 @@ public abstract class AuthenticationService extends Service {
     }
 
     /**
-     * Gets the password of the service.
-     *
-     * @return The user's ID.
-     */
-    public String getPassword() {
-        return this.password;
-    }
-
-    /**
      * Sets the username of the service.
      *
      * @param username Username to set.
@@ -90,19 +64,6 @@ public abstract class AuthenticationService extends Service {
             throw new IllegalStateException("Cannot change username while user is logged in and profile is selected.");
         } else {
             this.username = username;
-        }
-    }
-
-    /**
-     * Sets the password of the service.
-     *
-     * @param password Password to set.
-     */
-    public void setPassword(String password) {
-        if(this.loggedIn && this.selectedProfile != null) {
-            throw new IllegalStateException("Cannot change password while user is logged in and profile is selected.");
-        } else {
-            this.password = password;
         }
     }
 

--- a/src/main/java/com/github/steveice10/mc/auth/service/AuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/AuthenticationService.java
@@ -19,6 +19,7 @@ public abstract class AuthenticationService extends Service {
     protected String accessToken;
     protected boolean loggedIn;
     protected String username;
+    protected String password;
     protected GameProfile selectedProfile;
     protected List<GameProfile.Property> properties = new ArrayList<>();
     protected List<GameProfile> profiles = new ArrayList<>();
@@ -64,6 +65,28 @@ public abstract class AuthenticationService extends Service {
             throw new IllegalStateException("Cannot change username while user is logged in and profile is selected.");
         } else {
             this.username = username;
+        }
+    }
+
+    /**
+     * Gets the password of the service.
+     *
+     * @return The user's ID.
+     */
+    public String getPassword() {
+        return this.password;
+    }
+
+    /**
+     * Sets the password of the service.
+     *
+     * @param password Password to set.
+     */
+    public void setPassword(String password) {
+        if(this.loggedIn && this.selectedProfile != null) {
+            throw new IllegalStateException("Cannot change password while user is logged in and profile is selected.");
+        } else {
+            this.password = password;
         }
     }
 

--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -18,6 +18,8 @@ public class MojangAuthenticationService extends AuthenticationService {
     private static final String INVALIDATE_ENDPOINT = "invalidate";
 
     private String id;
+    private String clientToken;
+    protected String password;
 
     /**
      * Creates a new AuthenticationService instance.
@@ -32,7 +34,7 @@ public class MojangAuthenticationService extends AuthenticationService {
      * @param clientToken Client token to use when making authentication requests.
      */
     public MojangAuthenticationService(String clientToken) {
-        super(clientToken, DEFAULT_BASE_URI);
+        super(DEFAULT_BASE_URI);
 
         if(clientToken == null) {
             throw new IllegalArgumentException("ClientToken cannot be null.");
@@ -48,6 +50,32 @@ public class MojangAuthenticationService extends AuthenticationService {
      */
     public String getId() {
         return this.id;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
+
+    /**
+     * Gets the password of the service.
+     *
+     * @return The user's ID.
+     */
+    public String getPassword() {
+        return this.password;
+    }
+
+    /**
+     * Sets the password of the service.
+     *
+     * @param password Password to set.
+     */
+    public void setPassword(String password) {
+        if(this.loggedIn && this.selectedProfile != null) {
+            throw new IllegalStateException("Cannot change password while user is logged in and profile is selected.");
+        } else {
+            this.password = password;
+        }
     }
 
     @Override

--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -19,7 +19,6 @@ public class MojangAuthenticationService extends AuthenticationService {
 
     private String id;
     private String clientToken;
-    protected String password;
 
     /**
      * Creates a new AuthenticationService instance.
@@ -54,28 +53,6 @@ public class MojangAuthenticationService extends AuthenticationService {
 
     public String getClientToken() {
         return clientToken;
-    }
-
-    /**
-     * Gets the password of the service.
-     *
-     * @return The user's ID.
-     */
-    public String getPassword() {
-        return this.password;
-    }
-
-    /**
-     * Sets the password of the service.
-     *
-     * @param password Password to set.
-     */
-    public void setPassword(String password) {
-        if(this.loggedIn && this.selectedProfile != null) {
-            throw new IllegalStateException("Cannot change password while user is logged in and profile is selected.");
-        } else {
-            this.password = password;
-        }
     }
 
     @Override

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -141,7 +141,7 @@ public class MsaAuthenticationService extends AuthenticationService {
     public String toString() {
         return "MsaAuthenticationService{" +
                 "deviceCode='" + this.deviceCode + '\'' +
-                ", clientToken='" + this.clientId + '\'' +
+                ", clientId='" + this.clientId + '\'' +
                 ", accessToken='" + this.accessToken + '\'' +
                 ", loggedIn=" + this.loggedIn +
                 ", username='" + this.username + '\'' +

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -110,6 +110,16 @@ public class MsaAuthenticationService extends AuthenticationService {
     public void login() throws RequestException {
         boolean token = this.clientId != null && !this.clientId.isEmpty();
         boolean device = this.deviceCode != null && !this.deviceCode.isEmpty();
+        boolean password = this.password != null && !this.password.isEmpty();
+        if(!token && !password) {
+            throw new InvalidCredentialsException("Invalid password or access token.");
+        }
+        if(password && (this.username == null || this.username.isEmpty())) {
+            throw new InvalidCredentialsException("Invalid username.");
+        }
+        if(password) {
+            // TODO: Password-based auth to generate token
+        }
         if(!device) {
             this.deviceCode = getAuthCode().device_code;
         }
@@ -145,6 +155,7 @@ public class MsaAuthenticationService extends AuthenticationService {
                 ", accessToken='" + this.accessToken + '\'' +
                 ", loggedIn=" + this.loggedIn +
                 ", username='" + this.username + '\'' +
+                ", password='" + this.password + '\'' +
                 ", selectedProfile=" + this.selectedProfile +
                 ", properties=" + this.properties +
                 ", profiles=" + this.profiles +


### PR DESCRIPTION
The new Microsoft authentication is an oath 2 authentication.
The abstract class AuthenticationService should no longer contain a password, because MsaAuthenticationService can't perform the authentication using email + password.

I have also removed clientToken from AuthenticationService, because MsaAuthenticationService does not have one.

My idea for the MinecraftProtocol.java is to remove any reference of clientToken, that is not part of the protocol (it's just part of the Mojang auth), and remove any usage of AuthenticationService.
Authentication should be handled by the library end-user by using the AuthenticationService before calling MinecraftProtocol.
MinecraftProtocol should expose only two contructors:
1. MinecraftProtocol(String username)
2. MinecraftProtocol(GameProfile profile, String accessToken)

I will send a pull request for MCProtocolLib as well, following what I've said here.